### PR TITLE
fix: benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,25 +139,15 @@ mm-go can sometimes be 5-10 times faster, if you are not careful it will be slow
 goos: linux
 goarch: amd64
 pkg: github.com/joetifa2003/mm-go
-cpu: Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
-BenchmarkHeapManaged-2   	1000000000	         0.09938 ns/op
-BenchmarkHeapManaged-2   	1000000000	         0.09482 ns/op
-BenchmarkHeapManaged-2   	1000000000	         0.09476 ns/op
-BenchmarkHeapManaged-2   	1000000000	         0.09554 ns/op
-BenchmarkHeapManaged-2   	1000000000	         0.08969 ns/op
-BenchmarkArenaManual-2   	1000000000	         0.005030 ns/op
-BenchmarkArenaManual-2   	1000000000	         0.008007 ns/op
-BenchmarkArenaManual-2   	1000000000	         0.008574 ns/op
-BenchmarkArenaManual-2   	1000000000	         0.008318 ns/op
-BenchmarkArenaManual-2   	1000000000	         0.008397 ns/op
-BenchmarkSlice-2         	   96015	     12658 ns/op
-BenchmarkSlice-2         	  109916	     11724 ns/op
-BenchmarkSlice-2         	  112123	     11606 ns/op
-BenchmarkSlice-2         	  111018	     10988 ns/op
-BenchmarkSlice-2         	   99549	     11017 ns/op
-BenchmarkVector-2        	   50136	     23062 ns/op
-BenchmarkVector-2        	   69448	     22905 ns/op
-BenchmarkVector-2        	   75655	     16998 ns/op
-BenchmarkVector-2        	   73281	     18884 ns/op
-BenchmarkVector-2        	   77398	     17642 ns/op
+cpu: AMD Ryzen 5 3600 6-Core Processor              
+BenchmarkHeapManaged-12    	      79	  15561831 ns/op
+BenchmarkArenaManual-12    	     262	   4397339 ns/op
+BenchmarkSlice-12          	  151270	      7767 ns/op
+BenchmarkVector-12         	  131372	      9204 ns/op
+```
+Old results are go managed, New results are mm-go:
+```
+benchmark                         old ns/op     new ns/op     delta
+BenchmarkArenaHeapVsManual-12     15561831      4397339       -71.74%
+BenchmarkSliceVsVector-12         7767          9204          +18.50%
 ```

--- a/vector_test.go
+++ b/vector_test.go
@@ -1,13 +1,23 @@
 package mm
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
+// DoNotOptimise prevent the compiler removing the function bodies
+var DoNotOptimiseInts []int
+var DoNotOptimiseVector *Vector[int]
+
 func BenchmarkSlice(b *testing.B) {
-	for i := 0; i <= b.N; i++ {
+	// Start with a clean slate
+	DoNotOptimiseInts = nil
+	runtime.GC()
+	b.ResetTimer()
+
+	for i := b.N; i != 0; i-- {
 		numbers := []int{}
 
 		for j := 0; j < LOOP_TIMES; j++ {
@@ -18,13 +28,23 @@ func BenchmarkSlice(b *testing.B) {
 			// Pop
 			numbers = numbers[:len(numbers)-1]
 		}
+
+		DoNotOptimiseInts = numbers
 	}
+
+	runtime.GC()
+
+	DoNotOptimiseInts = nil
 }
 
 func BenchmarkVector(b *testing.B) {
-	for i := 0; i <= b.N; i++ {
+	// Start with a clean slate
+	DoNotOptimiseVector = nil
+	runtime.GC()
+	b.ResetTimer()
+
+	for i := b.N; i != 0; i-- {
 		numbersVec := NewVector[int]()
-		defer numbersVec.Free()
 
 		for j := 0; j < LOOP_TIMES; j++ {
 			numbersVec.Push(j)
@@ -33,7 +53,12 @@ func BenchmarkVector(b *testing.B) {
 		for j := 0; j < LOOP_TIMES; j++ {
 			numbersVec.Pop()
 		}
+
+		DoNotOptimiseVector = numbersVec
+		numbersVec.Free()
 	}
+
+	DoNotOptimiseVector = nil
 }
 
 func TestVector(t *testing.T) {


### PR DESCRIPTION
A single cycle is 0.333..ns at 3Ghz, the old benchmark results  didn't  made sense.

This was due to incorrect b.N iterations in some of the tests that only  ever runned one run of code.

I also added sinks for good mesure, that ensure the compiler don't  remove code from the function bodies.